### PR TITLE
Feat/nomenclature mixin

### DIFF
--- a/backend/gn_module_individuals/migrations/0001_init_migrations.py
+++ b/backend/gn_module_individuals/migrations/0001_init_migrations.py
@@ -18,6 +18,7 @@ depends_on = None
 MODULE_CODE = "INDIVIDUALS"
 SCHEMA_NAME = "gn_individual"
 
+
 def upgrade():
     conn = op.get_bind()
     op.execute(sa.text(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA_NAME}"))

--- a/backend/gn_module_individuals/models/devices.py
+++ b/backend/gn_module_individuals/models/devices.py
@@ -6,6 +6,7 @@ from pypnusershub.db.models import User
 from pypnnomenclature.models import TNomenclatures
 from pypnnomenclature.utils import NomenclaturesMixin
 
+
 class TrackingDevices(NomenclaturesMixin, DB.Model):
     __tablename__ = "bib_tracking_devices"
     __table_args__ = {"schema": "gn_individual"}
@@ -26,19 +27,16 @@ class TrackingDevices(NomenclaturesMixin, DB.Model):
     provider_name = DB.Column(
         "provider_name",
         DB.Text,
-        nullable=True,
     )
 
     provider_device_id = DB.Column(
         "provider_device_id",
         DB.Text,
-        nullable=True,
     )
 
     id_referer = DB.Column(
         "id_referer",
         DB.Integer,
-        nullable=True,
     )
 
     comment = DB.Column(
@@ -61,6 +59,7 @@ class TrackingDevices(NomenclaturesMixin, DB.Model):
     meta_update_date = DB.Column(
         "meta_update_date",
         DB.DateTime,
+        nullable=True,
     )
 
     # Relationships

--- a/backend/gn_module_individuals/models/devices.py
+++ b/backend/gn_module_individuals/models/devices.py
@@ -1,17 +1,16 @@
 from geonature.utils.env import DB
 from flask import g
-from pypnnomenclature.models import TNomenclatures
+from sqlalchemy.dialects.postgresql import JSONB
 from geonature.core.gn_monitoring.models import TIndividuals
 from pypnusershub.db.models import User
-from sqlalchemy.dialects.postgresql import JSONB
+from pypnnomenclature.models import TNomenclatures
+from pypnnomenclature.utils import NomenclaturesMixin
 
-
-class TrackingDevices(DB.Model):
+class TrackingDevices(NomenclaturesMixin, DB.Model):
     __tablename__ = "bib_tracking_devices"
     __table_args__ = {"schema": "gn_individual"}
 
     id_tracking_device = DB.Column(
-        "id_tracking_device",
         DB.Integer,
         primary_key=True,
         autoincrement=True,
@@ -20,8 +19,8 @@ class TrackingDevices(DB.Model):
     id_nomenclature_device_type = DB.Column(
         "id_nomenclature_device_type",
         DB.Integer,
-        DB.ForeignKey("ref_nomenclatures.t_nomenclatures.id_nomenclature"),
-        nullable=True,
+        # DB.ForeignKey("ref_nomenclatures.t_nomenclatures.id_nomenclature"),
+        DB.ForeignKey(TNomenclatures.id_nomenclature),
     )
 
     provider_name = DB.Column(
@@ -52,27 +51,24 @@ class TrackingDevices(DB.Model):
         "id_digitiser",
         DB.Integer,
         DB.ForeignKey("utilisateurs.t_roles.id_role"),
-        nullable=True,
     )
 
     meta_create_date = DB.Column(
         "meta_create_date",
         DB.DateTime,
-        nullable=True,
     )
 
     meta_update_date = DB.Column(
         "meta_update_date",
         DB.DateTime,
-        nullable=True,
     )
 
     # Relationships
     nomenclature_device_type = DB.relationship(
         TNomenclatures,
-        primaryjoin=(TNomenclatures.id_nomenclature == id_nomenclature_device_type),
+        # primaryjoin=(TNomenclatures.id_nomenclature == id_nomenclature_device_type),
         foreign_keys=[id_nomenclature_device_type],
-        lazy="select",
+        # lazy="select",
     )
 
     referer = DB.relationship(

--- a/backend/gn_module_individuals/routes/devices.py
+++ b/backend/gn_module_individuals/routes/devices.py
@@ -30,6 +30,12 @@ from ..blueprint import blueprint
 @permissions.check_cruved_scope("R", get_scope=True, module_code=MODULE_CODE)
 @json_resp
 def device(id_tracking_device, scope):
+    # Build nomenclatures fields list to serialize 
+    nomenclatures = list(TrackingDevices.__nomenclatures__)
+    nomenclatures_fields = [n for n in nomenclatures]
+
+    schema = TrackingDevicesListSchema(only=["+cruved","referer"] + nomenclatures_fields)
+
     query = (
         db.select(TrackingDevices)
         .options(
@@ -46,7 +52,7 @@ def device(id_tracking_device, scope):
     if device is None:
         raise NotFound(f"Le matériel de suivi {id_tracking_device} n'a pas été trouvé")
 
-    return TrackingDevicesDetailSchema(only=["nomenclature_device_type", "referer", "+cruved"]).dump(device)
+    return schema.dump(device)
 
 
 @blueprint.route("/devices", methods=["GET"])
@@ -54,7 +60,11 @@ def device(id_tracking_device, scope):
 @permissions.check_cruved_scope("R", get_scope=True, module_code=MODULE_CODE)
 @json_resp
 def list_devices(scope):
-    # Scope not used 
+    # Build nomenclatures fields list to serialize 
+    nomenclatures = list(TrackingDevices.__nomenclatures__)
+    nomenclatures_fields = [n for n in nomenclatures]
+
+    # Scope not yet used -------------
     device_type = request.args.get("type", type=int)
     provider_name = request.args.get("providerName", type=str)
     provider_id = request.args.get("providerDeviceId", type=str)
@@ -67,7 +77,7 @@ def list_devices(scope):
 
     paginated = page is not None and per_page is not None
 
-    schema = TrackingDevicesListSchema(many=True, only=["+cruved"])
+    schema = TrackingDevicesListSchema(only=["+cruved","referer"] + nomenclatures_fields)
 
     sort_col = getattr(TrackingDevices, prop, None)
 
@@ -92,7 +102,7 @@ def list_devices(scope):
     if paginated:
         pagination = db.paginate(query, page=page, per_page=per_page, error_out=False)
         return {
-            "items": schema.dump(pagination.items),
+            "items": schema.dump(pagination.items, many=True),
             "page": pagination.page,
             "per_page": pagination.per_page,
             "total": pagination.total,
@@ -104,7 +114,7 @@ def list_devices(scope):
         }
     else:
         items = db.session.execute(query).unique().scalars().all()
-        return schema.dump(items)
+        return schema.dump(items, many=True)
 
 
 @blueprint.route("/devices", methods=["POST"])
@@ -117,7 +127,7 @@ def create_device(scope):
     if not data:
         raise BadRequest("Corps de requête JSON manquant.")
 
-    schema = TrackingDevicesWriteSchema(exclude=("deployments",), unknown=EXCLUDE)
+    schema = TrackingDevicesWriteSchema(unknown=EXCLUDE)
     try:
         device = schema.load(data)
     except ValidationError as e:

--- a/backend/gn_module_individuals/routes/devices.py
+++ b/backend/gn_module_individuals/routes/devices.py
@@ -30,11 +30,11 @@ from ..blueprint import blueprint
 @permissions.check_cruved_scope("R", get_scope=True, module_code=MODULE_CODE)
 @json_resp
 def device(id_tracking_device, scope):
-    # Build nomenclatures fields list to serialize 
+    # Build nomenclatures fields list to serialize
     nomenclatures = list(TrackingDevices.__nomenclatures__)
     nomenclatures_fields = [n for n in nomenclatures]
 
-    schema = TrackingDevicesListSchema(only=["+cruved","referer"] + nomenclatures_fields)
+    schema = TrackingDevicesDetailSchema(only=["+cruved", "referer"] + nomenclatures_fields)
 
     query = (
         db.select(TrackingDevices)
@@ -60,7 +60,7 @@ def device(id_tracking_device, scope):
 @permissions.check_cruved_scope("R", get_scope=True, module_code=MODULE_CODE)
 @json_resp
 def list_devices(scope):
-    # Build nomenclatures fields list to serialize 
+    # Build nomenclatures fields list to serialize
     nomenclatures = list(TrackingDevices.__nomenclatures__)
     nomenclatures_fields = [n for n in nomenclatures]
 
@@ -77,7 +77,7 @@ def list_devices(scope):
 
     paginated = page is not None and per_page is not None
 
-    schema = TrackingDevicesListSchema(only=["+cruved","referer"] + nomenclatures_fields)
+    schema = TrackingDevicesListSchema(only=["+cruved", "referer"] + nomenclatures_fields)
 
     sort_col = getattr(TrackingDevices, prop, None)
 
@@ -119,10 +119,13 @@ def list_devices(scope):
 
 @blueprint.route("/devices", methods=["POST"])
 @login_required
-@permissions.check_cruved_scope("C", get_scope=True, module_code=MODULE_CODE, object_code="INDIVIDUALS_INDIVIDUALS")
+@permissions.check_cruved_scope(
+    "C", get_scope=True, module_code=MODULE_CODE, object_code="INDIVIDUALS_INDIVIDUALS"
+)
 @json_resp
 def create_device(scope):
     data = request.get_json()
+    print(f"POST data: {data}")
 
     if not data:
         raise BadRequest("Corps de requête JSON manquant.")
@@ -143,7 +146,9 @@ def create_device(scope):
 
 @blueprint.route("/devices/<int(signed=True):id_tracking_device>", methods=["PUT"])
 @login_required
-@permissions.check_cruved_scope("U", get_scope=True, module_code=MODULE_CODE, object_code="INDIVIDUALS_INDIVIDUALS")
+@permissions.check_cruved_scope(
+    "U", get_scope=True, module_code=MODULE_CODE, object_code="INDIVIDUALS_INDIVIDUALS"
+)
 @json_resp
 def update_device(id_tracking_device, scope):
     device = db.session.get(TrackingDevices, id_tracking_device)
@@ -174,7 +179,9 @@ def update_device(id_tracking_device, scope):
 
 @blueprint.route("/devices/<int(signed=True):id_tracking_device>", methods=["DELETE"])
 @login_required
-@permissions.check_cruved_scope("D", get_scope=True, module_code=MODULE_CODE, object_code="INDIVIDUALS_INDIVIDUALS")
+@permissions.check_cruved_scope(
+    "D", get_scope=True, module_code=MODULE_CODE, object_code="INDIVIDUALS_INDIVIDUALS"
+)
 def delete_device(id_tracking_device, scope):
     device = db.session.get(TrackingDevices, id_tracking_device)
     if device is None:

--- a/backend/gn_module_individuals/schemas/devices.py
+++ b/backend/gn_module_individuals/schemas/devices.py
@@ -15,7 +15,9 @@ from .deployments import DeploymentSummarySchema
 from .utils import get_label
 
 
-class TrackingDevicesBaseSchema(CruvedSchemaMixin, SmartRelationshipsMixin, ma.SQLAlchemyAutoSchema):
+class TrackingDevicesBaseSchema(
+    CruvedSchemaMixin, SmartRelationshipsMixin, ma.SQLAlchemyAutoSchema
+):
     class Meta:
         model = TrackingDevices
         include_fk = True
@@ -31,7 +33,7 @@ class TrackingDevicesBaseSchema(CruvedSchemaMixin, SmartRelationshipsMixin, ma.S
     id_tracking_device = ma.auto_field(dump_only=True)
     meta_create_date = fields.Date(format="%Y-%m-%d", dump_only=True)
     meta_update_date = fields.Date(format="%Y-%m-%d", dump_only=True)
-    comment = fields.Method("get_comment", dump_only=True)
+    comment = ma.auto_field()
 
     nomenclature_device_type_name = fields.Method("get_nomenclature_name", dump_only=True)
     digitiser_name = fields.Method("get_digitiser_name", dump_only=True)
@@ -75,11 +77,6 @@ class TrackingDevicesBaseSchema(CruvedSchemaMixin, SmartRelationshipsMixin, ma.S
         return value
 
     # Serialisation
-
-    def get_comment(self, obj):
-        if obj.comment:
-            return obj.comment.replace("\n", "<br>")
-        return None
 
     def get_nomenclature_name(self, obj):
         if obj.nomenclature_device_type:

--- a/backend/gn_module_individuals/tests/conftest.py
+++ b/backend/gn_module_individuals/tests/conftest.py
@@ -82,12 +82,12 @@ def ensure_individuals_module(app, users):
     # Permissions sur ALL (lecture globale du module)
     all_permissions = {
         "admin_user": {"actions": "RV", "scope": None},
-        "self_user":  {"actions": "R",  "scope": 1},
+        "self_user": {"actions": "R", "scope": 1},
     }
     # Permissions sur INDIVIDUALS_INDIVIDUALS (C/U/D discriminés)
     individuals_permissions = {
         "admin_user": {"actions": "CUD", "scope": None},
-        "self_user":  {"actions": "U",   "scope": 1},
+        "self_user": {"actions": "U", "scope": 1},
     }
 
     def _add_permissions(target_map, perm_object):
@@ -109,13 +109,15 @@ def ensure_individuals_module(app, users):
                         )
                     )
                     if exists is None:
-                        db.session.add(Permission(
-                            id_role=user.id_role,
-                            id_module=module.id_module,
-                            id_action=action.id_action,
-                            id_object=perm_object.id_object,
-                            scope_value=config["scope"],
-                        ))
+                        db.session.add(
+                            Permission(
+                                id_role=user.id_role,
+                                id_module=module.id_module,
+                                id_action=action.id_action,
+                                id_object=perm_object.id_object,
+                                scope_value=config["scope"],
+                            )
+                        )
 
     _add_permissions(all_permissions, object_all)
     _add_permissions(individuals_permissions, object_individuals)


### PR DESCRIPTION
Add `NomenclatureMixin` on the `TrackingDevice` model to facilitate nomenclatures fields serialization. Really intresting to use it on others models (cf [Doc Geonature](https://github.com/PnX-SI/GeoNature/blob/master/docs/development.rst#mod%C3%A8les-avec-nomenclatures))

J'ai modifié aussi le modèle car certains champs sont nullables alors qu'il avudrait mieux qu'ils ne le soient pas. Les seuls à priori qui peuvent l'être sont comment et meta_update_date.

J'ai aussi supprimé la méthode get_comment dans le schéma qui avait 2 effets : 
- Le `<br>` n'est pas directement interprêté par le front, il fera donc lui la conversion du \n en <br> ... ce qui est en plus une spécificité html. Si les données sont récupérées autrement, cela n'aurait plus de sans.
- l'attribut `comment` défini avec `fields.Method()` ne permettait pas l'écriture sur ce champs, il faut un `ma.auto_field()`

Autre chose : Est-ce que ça vaudrait pas le coup d'insérer les données de test en utilisant les fonctions alembics, ça permettrait ainsi de tester les modèles  ... à voir